### PR TITLE
fix: Skip processing a key when its value is null or undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,18 @@ class ServerlessAWSCloudFormationSubVariables {
             return '\u001B[33m' + message + '\u001B[39m';
         }
 
+        function isNull(node) {
+            return node === null;
+        }
+
+        function isUndefined(node) {
+            return node === undefined;
+        }
+
+        function isNil(node) {
+            return isNull(node) || isUndefined(node);
+        }
+
         function isArray(node) {
             return node.constructor == Array;
         }
@@ -35,6 +47,9 @@ class ServerlessAWSCloudFormationSubVariables {
 
         function recurseNode(node, subFunctionChild) {
             Object.keys(node).forEach((key) => {
+                if (isNil(node[key])) {
+                    return;
+                }
                 if (hasChildren(node[key])) {
                     recurseNode(node[key], isSubFunction(key) ? true : false)
                 }


### PR DESCRIPTION
**Steps to reproduce**

1. Create a Serverless Framework project
1. Install serverless-cloudformation-sub-variables
1. Install another plugin that places null or undefined values into the graph, such as [this one](https://github.com/ACloudGuru/serverless-plugin-aws-alerts)

**Expected Result**

The plugin should gracefully handle cases where values are set to null or undefined.

**Actual Result**

The plugin chokes when it attempts to access the constructor member of undefined or null (`node.construtor`).  It didn't check for undefined or null.

**Why not fix the offending plugin?  It's the one introducing undefined / null**

There are a lot of plugins in the big, bad world.  Attempting to fix them all is a fool's game.  I've only found one such instance.  Instead, we can make this plugin more robust by programming defensively.

**What this pull request does**

During recursion, if a key's value is null or undefined, there are no further attempts to access members – because there aren't any to access.
