### PR TITLE
Add ability to customize search pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,22 +45,24 @@ class ServerlessAWSCloudFormationSubVariables {
             return keyName == 'Fn::Sub'
         }
 
-        function recurseNode(node, subFunctionChild) {
+        function recurseNode(node, subFunctionChild, config) {
             Object.keys(node).forEach((key) => {
+                let searchRegex = new RegExp(`${config.prefix}([^}]+)${config.suffix}`)
+                let replaceRegex = new RegExp(`${config.prefix}([^}]+)${config.suffix}`, 'g')
                 if (isNil(node[key])) {
                     return;
                 }
                 if (hasChildren(node[key])) {
-                    recurseNode(node[key], isSubFunction(key) ? true : false)
+                    recurseNode(node[key], isSubFunction(key) ? true : false, config)
                 }
-                else if (isString(node[key]) && node[key].search(/#{([^}]+)}/) != -1) {
-                    let convertedNodeValue = node[key].replace(/#{([^}]+)}/g, '${$1}')
+                else if (isString(node[key]) && node[key].search(searchRegex) != -1) {
+                    let convertedNodeValue = node[key].replace(replaceRegex, '${$1}')
                     if (subFunctionChild) {
-                        consoleLog('Serverless: ' + toYellow(' - \'' + node[key] + '\' => \'' + node[key].replace(/#{([^}]+)}/g, '${$1}') + '\''))
+                        consoleLog('Serverless: ' + toYellow(' - \'' + node[key] + '\' => \'' + node[key].replace(replaceRegex, '${$1}') + '\''))
                         node[key] = convertedNodeValue
                     }
                     else {
-                        consoleLog('Serverless: ' + toYellow(' - \'' + node[key] + '\' => \'{\"Fn::Sub\": \"' + node[key].replace(/#{([^}]+)}/g, '${$1}') + '\"}\''))
+                        consoleLog('Serverless: ' + toYellow(' - \'' + node[key] + '\' => \'{\"Fn::Sub\": \"' + node[key].replace(replaceRegex, '${$1}') + '\"}\''))
                         node[key] = {
                             'Fn::Sub': convertedNodeValue
                         }
@@ -69,10 +71,16 @@ class ServerlessAWSCloudFormationSubVariables {
             });
         }
 
+        let config = {prefix: '#{', suffix: '}'}
+        if (this.serverless.service.custom && this.serverless.service.custom.sub) {
+          const sub = this.serverless.service.custom.sub
+          config.prefix = sub.prefix
+          config.suffix = sub.suffix
+        }
         const consoleLog = this.serverless.cli.consoleLog;
         consoleLog('Serverless: ' + toYellow('serverless-cloudformation-sub-variables: Converting AWS CloudFormation Sub variables...'));
         const cfnTemplate = this.serverless.service.provider.compiledCloudFormationTemplate
-        recurseNode(cfnTemplate, false)
+        recurseNode(cfnTemplate, false, config)
     }
 }
 


### PR DESCRIPTION
This adds the ability to customize the prefix and suffix of the search pattern.

My intention is written in more detail at https://forum.serverless.com/t/can-i-customize-the-valid-api-gateway-stage-name-pattern/9217

With this change I can create an API Gateway valid stage but one that is later replaced e.g. AbcStageXyz

The custom section in `serverless.yml` looks like
```
custom:
  sub:
    prefix: Abc
    suffix: Xyz
```