### PR TITLE
fix: Moved substitution to after mergeCustomProviderResources to supp…

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ class ServerlessAWSCloudFormationSubVariables {
     constructor(serverless) {
       this.serverless = serverless;
       this.hooks = {
-        'aws:package:finalize:mergeCustomProviderResources': this.convertSubVariables.bind(this)
+        'after:aws:package:finalize:mergeCustomProviderResources': this.convertSubVariables.bind(this)
       }
     }
 


### PR DESCRIPTION
Hi,

I was having this issue where substitution didn't work within the resources generated by the [appsync plugin](https://github.com/sid88in/serverless-appsync-plugin). For example, placing #{..} within datasources doesn't work. 

This seems mostly because it adds it's resources in `after:aws:package:finalize:mergeCustomProviderResources` step, which is after the substitution which happens in `aws:package:finalize:mergeCustomProviderResources`.

Changing the hook and placing the plugin below the appsync plugin seems to fix it for me. Hence this pull request.

Thanks in advance.
